### PR TITLE
Remove unncessary dependencies in travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,5 @@ branches:
 language: python
 python:
 - '3.4'
-before_script:
-- if [ -n "${GH_TOKEN}" ] && [ "${TRAVIS_BRANCH}" == "master" ] && [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then
-    pip install pygithub;
-    pip install pygithub3;
-  fi
 script:
 - python3 tools/sqf_validator.py


### PR DESCRIPTION
The github pip libraries are not necessary when just running the sqf validator